### PR TITLE
Big Sur compatibility (accessibility dialog box)

### DIFF
--- a/main.m
+++ b/main.m
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import <ApplicationServices/ApplicationServices.h>
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
When I launched the app on Big Sur, the Accessibility dialog box didn't show up, so it couldn't work
This workaround worked for me, sooo