### PR TITLE
Fix for no-name devices

### DIFF
--- a/KeyStroke.m
+++ b/KeyStroke.m
@@ -94,11 +94,13 @@ static void readProc(const MIDIPacketList *pktlist, void *refCon, void *connRefC
 		if(modelCheck != kMIDIUnknownProperty && pModel != nil) {
 			[mNum appendString:(NSString *)pModel];
 			[mNum appendString:@" "];
-		}
+        } else {
+            [mNum appendFormat:@"No-name Device #%d ", i];
+        }
         if( pName != nil ) {
 		  [mNum appendString:(NSString *)pName];
-		  [sourcePopup insertItemWithTitle:mNum atIndex:i+1];
         }
+        [sourcePopup insertItemWithTitle:mNum atIndex:i+1];
 	}
 	CFRelease(sourceArray);
 }


### PR DESCRIPTION
Add placeholder text for MIDI devices that don't return a name, allowing them to still be used.  This fixes devices such as Novation Launchpad.  

I think the MIDICore structure of such devices is more complex and the name can be recovered with some difficulty, but sample code from Apple did not work.

Fixes #18